### PR TITLE
Added docstrings to file_rados_parquet.cc/h

### DIFF
--- a/cpp/src/arrow/dataset/file_rados_parquet.cc
+++ b/cpp/src/arrow/dataset/file_rados_parquet.cc
@@ -40,6 +40,7 @@ namespace flatbuf = org::apache::arrow::flatbuf;
 
 namespace dataset {
 
+/// \brief A ScanTask backed by an RadosParquet file.
 class RadosParquetScanTask : public ScanTask {
  public:
   RadosParquetScanTask(std::shared_ptr<ScanOptions> options,

--- a/cpp/src/arrow/dataset/file_rados_parquet.h
+++ b/cpp/src/arrow/dataset/file_rados_parquet.h
@@ -75,7 +75,7 @@ class ARROW_DS_EXPORT RadosCluster {
   ~RadosCluster() { Shutdown(); }
 
   /// \brief Connect to the Rados cluster.
-  /// \return Status of the attempted connection.
+  /// \return Status.
   Status Connect() {
     if (rados->init2(ctx.user_name.c_str(), ctx.cluster_name.c_str(), 0))
       return Status::Invalid("librados::init2 returned non-zero exit code.");
@@ -93,7 +93,7 @@ class ARROW_DS_EXPORT RadosCluster {
   }
 
   /// \brief Shutdown the connection to the Rados cluster.
-  /// \return Status of the attempted shutdown.
+  /// \return Status.
   Status Shutdown() {
     rados->shutdown();
     return Status::OK();
@@ -115,7 +115,7 @@ class ARROW_DS_EXPORT DirectObjectAccess {
   /// \brief Executes the POSIX stat call on a file.
   /// \param[in] path Path of the file.
   /// \param[out] st Refernce to the struct object to store the result.
-  /// \return Status of the attempted POSIX stat call.
+  /// \return Status.
   Status Stat(const std::string& path, struct stat& st) {
     struct stat file_st;
     if (stat(path.c_str(), &file_st) < 0)
@@ -137,7 +137,7 @@ class ARROW_DS_EXPORT DirectObjectAccess {
   /// \param[in] fn The function to be executed by the librados::exec call.
   /// \param[in] in The input buffer.
   /// \param[out] in The output buffer.
-  /// \return Status of the attempted librados::exec call.
+  /// \return Status.
   Status Exec(uint64_t inode, const std::string& fn, ceph::bufferlist& in,
               ceph::bufferlist& out) {
     std::string oid = ConvertFileInodeToObjectID(inode);

--- a/cpp/src/arrow/dataset/file_rados_parquet.h
+++ b/cpp/src/arrow/dataset/file_rados_parquet.h
@@ -54,6 +54,12 @@
 namespace arrow {
 namespace dataset {
 
+/// \addtogroup dataset-file-formats
+///
+/// @{
+
+/// \brief A class that specifies the connection and disconnection from the
+/// Rados cluster with the config options.
 class ARROW_DS_EXPORT RadosCluster {
  public:
   struct RadosConnectionCtx {
@@ -68,6 +74,7 @@ class ARROW_DS_EXPORT RadosCluster {
 
   ~RadosCluster() { Shutdown(); }
 
+  /// \brief Connect to the Rados cluster.
   Status Connect() {
     if (rados->init2(ctx.user_name.c_str(), ctx.cluster_name.c_str(), 0))
       return Status::Invalid("librados::init2 returned non-zero exit code.");
@@ -84,6 +91,7 @@ class ARROW_DS_EXPORT RadosCluster {
     return Status::OK();
   }
 
+  /// \brief Disconnect the Rados cluster.
   Status Shutdown() {
     rados->shutdown();
     return Status::OK();
@@ -94,11 +102,13 @@ class ARROW_DS_EXPORT RadosCluster {
   IoCtxInterface* ioCtx;
 };
 
+/// \brief Defines the file operations and access methods.
 class ARROW_DS_EXPORT DirectObjectAccess {
  public:
   explicit DirectObjectAccess(const std::shared_ptr<RadosCluster>& cluster)
       : cluster_(std::move(cluster)) {}
 
+  /// \brief Get stat information about the file.
   Status Stat(const std::string& path, struct stat& st) {
     struct stat file_st;
     if (stat(path.c_str(), &file_st) < 0)
@@ -114,6 +124,7 @@ class ARROW_DS_EXPORT DirectObjectAccess {
     return oid;
   }
 
+  /// \brief Executes query on the librados node.
   Status Exec(uint64_t inode, const std::string& fn, ceph::bufferlist& in,
               ceph::bufferlist& out) {
     std::string oid = ConvertFileInodeToObjectID(inode);
@@ -128,6 +139,8 @@ class ARROW_DS_EXPORT DirectObjectAccess {
   std::shared_ptr<RadosCluster> cluster_;
 };
 
+/// \brief A ParquetFileFormat implementation that offloads the computation
+/// for the queries onto server Ceph nodes.
 class ARROW_DS_EXPORT RadosParquetFileFormat : public ParquetFileFormat {
  public:
   explicit RadosParquetFileFormat(const std::string&, const std::string&,
@@ -146,8 +159,10 @@ class ARROW_DS_EXPORT RadosParquetFileFormat : public ParquetFileFormat {
 
   Result<bool> IsSupported(const FileSource& source) const override { return true; }
 
+  /// \brief Return the schema of the file if possible.
   Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
 
+  /// \brief Open a file for scanning.
   Result<ScanTaskIterator> ScanFile(
       const std::shared_ptr<ScanOptions>& options,
       const std::shared_ptr<FileFragment>& file) const override;
@@ -177,6 +192,8 @@ ARROW_DS_EXPORT Status SerializeTable(std::shared_ptr<Table>& table,
                                       ceph::bufferlist& bl);
 
 ARROW_DS_EXPORT Status DeserializeTable(RecordBatchVector& batches, ceph::bufferlist& bl);
+
+/// @}
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_rados_parquet.h
+++ b/cpp/src/arrow/dataset/file_rados_parquet.h
@@ -58,8 +58,8 @@ namespace dataset {
 ///
 /// @{
 
-/// \brief A class that specifies the connection and disconnection from the
-/// Rados cluster with the config options.
+/// \brief An interface to connect to a RADOS cluster and hold the connection
+/// information for usage in later stages.
 class ARROW_DS_EXPORT RadosCluster {
  public:
   struct RadosConnectionCtx {
@@ -75,6 +75,7 @@ class ARROW_DS_EXPORT RadosCluster {
   ~RadosCluster() { Shutdown(); }
 
   /// \brief Connect to the Rados cluster.
+  /// \return Status of the attempted connection.
   Status Connect() {
     if (rados->init2(ctx.user_name.c_str(), ctx.cluster_name.c_str(), 0))
       return Status::Invalid("librados::init2 returned non-zero exit code.");
@@ -91,7 +92,8 @@ class ARROW_DS_EXPORT RadosCluster {
     return Status::OK();
   }
 
-  /// \brief Disconnect the Rados cluster.
+  /// \brief Shutdown the connection to the Rados cluster.
+  /// \return Status of the attempted shutdown.
   Status Shutdown() {
     rados->shutdown();
     return Status::OK();
@@ -102,13 +104,18 @@ class ARROW_DS_EXPORT RadosCluster {
   IoCtxInterface* ioCtx;
 };
 
-/// \brief Defines the file operations and access methods.
+/// \brief Interface for translating the name of a file in CephFS to its
+/// corresponding object ID in RADOS assuming 1:1 mapping between a file
+/// and its underlying object.
 class ARROW_DS_EXPORT DirectObjectAccess {
  public:
   explicit DirectObjectAccess(const std::shared_ptr<RadosCluster>& cluster)
       : cluster_(std::move(cluster)) {}
 
-  /// \brief Get stat information about the file.
+  /// \brief Executes the POSIX stat call on a file.
+  /// \param[in] path Path of the file.
+  /// \param[out] st Refernce to the struct object to store the result.
+  /// \return Status of the attempted POSIX stat call.
   Status Stat(const std::string& path, struct stat& st) {
     struct stat file_st;
     if (stat(path.c_str(), &file_st) < 0)
@@ -124,7 +131,13 @@ class ARROW_DS_EXPORT DirectObjectAccess {
     return oid;
   }
 
-  /// \brief Executes query on the librados node.
+  /// \brief Executes query on the librados node. It uses the librados::exec API to
+  /// perform queries on the storage node and stores the result in the output buffer.
+  /// \param[in] inode inode of the file.
+  /// \param[in] fn The function to be executed by the librados::exec call.
+  /// \param[in] in The input buffer.
+  /// \param[out] in The output buffer.
+  /// \return Status of the attempted librados::exec call.
   Status Exec(uint64_t inode, const std::string& fn, ceph::bufferlist& in,
               ceph::bufferlist& out) {
     std::string oid = ConvertFileInodeToObjectID(inode);
@@ -139,8 +152,8 @@ class ARROW_DS_EXPORT DirectObjectAccess {
   std::shared_ptr<RadosCluster> cluster_;
 };
 
-/// \brief A ParquetFileFormat implementation that offloads the computation
-/// for the queries onto server Ceph nodes.
+/// \brief A ParquetFileFormat implementation that offloads the fragment
+/// scan operations to the Ceph OSDs
 class ARROW_DS_EXPORT RadosParquetFileFormat : public ParquetFileFormat {
  public:
   explicit RadosParquetFileFormat(const std::string&, const std::string&,
@@ -159,10 +172,15 @@ class ARROW_DS_EXPORT RadosParquetFileFormat : public ParquetFileFormat {
 
   Result<bool> IsSupported(const FileSource& source) const override { return true; }
 
-  /// \brief Return the schema of the file if possible.
+  /// \brief Return the schema of the file fragment.
+  /// \param[in] source The source of the file fragment.
+  /// \return The schema of the file fragment.
   Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
 
-  /// \brief Open a file for scanning.
+  /// \brief Scan a file fragment.
+  /// \param[in] options Options to pass.
+  /// \param[in] file The file fragment.
+  /// \return The scanned file fragment.
   Result<ScanTaskIterator> ScanFile(
       const std::shared_ptr<ScanOptions>& options,
       const std::shared_ptr<FileFragment>& file) const override;


### PR DESCRIPTION
This PR adds docstrings to file_rados_parquet.cc and file_rados_parquet.h files.
The docstrings follow the current upstream arrow repo standards. The docstrings still need to be improved and approved before merging.