### PR TITLE
Cleaned up some error handling.

### DIFF
--- a/cpp/src/skyhook/protocol/skyhook_protocol.h
+++ b/cpp/src/skyhook/protocol/skyhook_protocol.h
@@ -57,12 +57,13 @@ struct ScanRequest {
 /// Utility functions to serialize and deserialize scan requests and result Arrow tables.
 arrow::Status SerializeScanRequest(ScanRequest req, ceph::bufferlist& bl);
 arrow::Status DeserializeScanRequest(ScanRequest& req, ceph::bufferlist bl);
-arrow::Status SerializeTable(std::shared_ptr<arrow::Table> table, ceph::bufferlist& bl);
+arrow::Status SerializeTable(const std::shared_ptr<arrow::Table>& table,
+                             ceph::bufferlist& bl);
 arrow::Status DeserializeTable(arrow::RecordBatchVector& batches, ceph::bufferlist bl,
                                bool use_threads);
 
 /// Utility function to invoke a RADOS object class function on an RADOS object.
-arrow::Status ExecuteObjectClassFn(std::shared_ptr<rados::RadosConn> connection_,
+arrow::Status ExecuteObjectClassFn(const std::shared_ptr<rados::RadosConn>& connection,
                                    const std::string& oid, const std::string& fn,
                                    ceph::bufferlist& in, ceph::bufferlist& out);
 


### PR DESCRIPTION
Try and avoid `ValueOrDie` at all costs because that will assert and crash the program instead of propagating the error.  This PR should replace most (all?) instances of ValueOrDie with ARROW_ASSIGN_OR_RAISE which is the preferred method of handling errors.  In a few spots ARROW_ASSIGN_OR_RAISE was not appropriate (since the return value of the function was not Status/Result) and so I manually inspected the status, reported the error, and bailed out gracefully.